### PR TITLE
Fixed js error where no metas are defined

### DIFF
--- a/src/logmatic.js
+++ b/src/logmatic.js
@@ -9,6 +9,7 @@
   }
 }(this, function () {
   var _url;
+  var _metas;
   var _ipTrackingAttr;
   var _uaTrackingAttr;
 


### PR DESCRIPTION
In the case where no metas are set, we have a js error. Declare `_metas` var for further usage.