### PR TITLE
adding npm common js compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ You simply have to include the minified script and initialize it with your write
 </html>
 ```
 
+Or using npm:
+
+    npm install --save logmatic/logmatic-js#master
+
+```javascript
+// commonjs
+var logmatic = require('logmatic-js');
+// ES2015
+import logmatic from 'logmatic-js';
+
+// Set your API key
+logmatic.init('<your_api_key>');
+// ...
+// same as before
+```
+
 ### Log some events
 
 To log some events you simply there is simple an unique method called *log(<message>,<context>)*. The message is a piece of text, the context is an object that you want to associate to the message.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "logmatic-js",
   "version": "0.0.7",
   "description": "Client-side JavaScript logging library for Logmatic.io",
-  "main": "product/logmatic.js",
+  "main": "src/logmatic.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/logmatic/logmatic-js"


### PR DESCRIPTION
This update is just setting the main parameter correctly in the package.json to be able to use it inside a build tool based on npm rather than using it inside of a script tag directly on the html.

As added to the readme, the older version didn't allow for a module import (the product directory did not exists) and the readme addon is just to let users know how to get package from github without using npm. 

Though you could publish it on npm if you wanted :)