### PR TITLE
Adds a default value to `_metas`

### DIFF
--- a/src/logmatic.js
+++ b/src/logmatic.js
@@ -9,7 +9,7 @@
 }(this, function () {
 
   var _url = 'https://api.logmatic.io/v1/input/';
-  var _metas;
+  var _metas = {};
   var _ipTrackingAttr;
   var _uaTrackingAttr;
   var _urlTrackingAttr;


### PR DESCRIPTION
Before the PR, calling `addMeta` without a prior `setMetas` throws an expection, because `_metas` is undefined.